### PR TITLE
Data loading & preprocessing pipeline (Issue #49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-data/
+data/**
+!data/*.py
 *.csv
 *.parquet
 *.json

--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ The datasets are not stored in this repository. To download them, follow these s
 2. uv sync
 3. python download_data.py
 
+## Codebook (cleaned dataset)
+
+The cleaned dataset is produced by running `python data/clean.py` and includes:
+
+- **Row filtering**
+  - Keeps records where `date` is in **[2001-01-01, 2026-01-01)** (i.e., up to 2025-12-31).
+  - Drops rows with missing **`latitude`** or **`longitude`**.
+
+- **Temporal features (added)**
+  - **`Year`**: year extracted from `date`
+  - **`Month`**: month extracted from `date`
+  - **`Day`**: day-of-month extracted from `date`
+  - **`Hour`**: hour extracted from `date`
+  - **`Day of Week`**: weekday name extracted from `date`
+
+- **Categorical columns (when using Parquet output)**
+  - Converts suitable columns to categorical to reduce memory usage (e.g., `primary_type`, `description`, `location_description`, `iucr`, `fbi_code`, `Day of Week`).
+  - **Note**: categories are best preserved in **Parquet** (`--format parquet`).
+
 ## Development Workflow
 
 To maintain code quality and ensure collaboration, please follow this workflow:

--- a/data/clean.py
+++ b/data/clean.py
@@ -1,153 +1,104 @@
-# ==============================================================================
-# This is how we are cleaning the data 
-# ==============================================================================
+"""
+Clean and preprocess the Chicago Crimes dataset (2001–2025).
 
-# ── Loading libraries ─────────────────────────────────────────────────────────
+Implements Issue #49 tasks:
+- drop rows with missing latitude/longitude
+- extract temporal features: Year, Month, Day, Hour, Day of Week
+- convert suitable columns to categorical (best preserved in Parquet)
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
 import pandas as pd
-import os
 
-# ── Load data ─────────────────────────────────────────────────────────────────
-RAW_DATA_PATH = 'data/raw/chicago_crimes_2001_2025_raw.csv'
 
-if not os.path.exists(RAW_DATA_PATH):
-    print("Raw data not found. Please run download_data.py first.")
-    exit(1)
+RAW_DEFAULT = "data/raw/chicago_crimes_2001_2025_raw.csv"
+OUT_DEFAULT_CSV = "data/cleaned/chicago_crimes_cleaned.csv"
+OUT_DEFAULT_PARQUET = "data/cleaned/chicago_crimes_cleaned.parquet"
 
-print("Loading raw data...")
-df = pd.read_csv(RAW_DATA_PATH, low_memory=False)
 
-# ── Basic info ────────────────────────────────────────────────────────────────
-print(df.describe())
-print(df.shape)
-print(df.dtypes)
-print(df.columns.tolist())
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    # Normalize column names to expected lowercase snake-ish naming used across repo.
+    df = df.copy()
+    df.columns = [c.strip().lower() for c in df.columns]
 
-# ── Filter to 2001-2025 ───────────────────────────────────────────────────────
-df = df[df['year'].between(2001, 2025)]
-print(df['year'].value_counts().sort_index())
-print("\nTotal records (2001-2025):", len(df))
+    # Parse timestamp.
+    if "date" in df.columns:
+        dt = pd.to_datetime(df["date"], errors="coerce", utc=False)
+    else:
+        raise ValueError("Expected a 'date' column in the raw dataset.")
 
-# ── Missing value summary ─────────────────────────────────────────────────────
-missing = df.isnull().sum()
-missing_pct = (missing / len(df) * 100).round(2)
+    # Filter to 2001–2025 using timestamp (more robust than relying on 'year' column).
+    df = df[(dt >= "2001-01-01") & (dt < "2026-01-01")]
+    dt = dt.loc[df.index]
 
-missing_summary = pd.DataFrame({
-    "missing_count": missing,
-    "missing_pct": missing_pct
-}).sort_values("missing_pct", ascending=False)
+    # Drop rows with missing coordinates.
+    for col in ("latitude", "longitude"):
+        if col not in df.columns:
+            raise ValueError(f"Expected '{col}' column in the raw dataset.")
+    df = df.dropna(subset=["latitude", "longitude"])
+    dt = dt.loc[df.index]
 
-missing_summary
+    # Temporal features (capitalized names requested in Issue #49).
+    df["Year"] = dt.dt.year.astype("int16")
+    df["Month"] = dt.dt.month.astype("int8")
+    df["Day"] = dt.dt.day.astype("int8")
+    df["Hour"] = dt.dt.hour.astype("int8")
+    df["Day of Week"] = dt.dt.day_name()
 
-# ── Data type checks ──────────────────────────────────────────────────────────
-# fbi_code and iucr are strings, which is correct - they are category codes
-print(df.dtypes)
-df.info()
+    # Standardize types for numeric codes where appropriate.
+    for col in ("district", "ward", "community_area"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
 
-# Verify arrest and domestic are boolean
-print("arrest unique values:", df["arrest"].unique())
-print("domestic unique values:", df["domestic"].unique())
-#ok good
+    # Convert "code-like" and low-cardinality strings to categorical to reduce memory.
+    for col in ("primary_type", "description", "location_description", "iucr", "fbi_code", "Day of Week"):
+        if col in df.columns:
+            df[col] = df[col].astype("category")
 
-# ── Type conversions ──────────────────────────────────────────────────────────
+    # Remove redundant structured column if present.
+    if "location" in df.columns:
+        df = df.drop(columns=["location"])
 
-# date-time conversions
+    return df
 
-date_series = []
-for date in df['date']:
-    date_series.append(date[0:10])
 
-time_series = []
-for time in df['date']:
-    time_series.append(time[11:19])
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Clean/preprocess the Chicago Crimes dataset.")
+    parser.add_argument("--raw", default=RAW_DEFAULT, help="Path to raw CSV.")
+    parser.add_argument(
+        "--format",
+        choices=["csv", "parquet"],
+        default="parquet",
+        help="Output format (parquet recommended).",
+    )
+    parser.add_argument("--out", default=None, help="Output file path override.")
+    args = parser.parse_args()
 
-df['date'] = date_series
-df['time'] = time_series
+    raw_path = Path(args.raw)
+    if not raw_path.exists():
+        raise SystemExit(f"Raw data not found at {raw_path}. Run download_data.py first.")
 
-df['date'] = pd.to_datetime(df['date'], format = "%Y-%m-%d")
-df['time'] = pd.to_datetime(df['time'], format = "%H:%M:%S").dt.time
+    out_path = Path(
+        args.out
+        or (OUT_DEFAULT_PARQUET if args.format == "parquet" else OUT_DEFAULT_CSV)
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
 
-df[['date', 'time']].tail(10)
+    df = pd.read_csv(raw_path, low_memory=False)
+    cleaned = preprocess(df)
 
-# district, ward, community_area should be integer
-# Int64 (capital I) is used because these columns have missing values
-# regular int64 cannot store NaN, Int64 can
-df["district"]       = pd.to_numeric(df["district"], errors="coerce").astype("Int64")
-df["ward"]           = pd.to_numeric(df["ward"], errors="coerce").astype("Int64")
-df["community_area"] = pd.to_numeric(df["community_area"], errors="coerce").astype("Int64")
+    if args.format == "parquet":
+        cleaned.to_parquet(out_path, index=False)
+    else:
+        cleaned.to_csv(out_path, index=False)
 
-# Recode categorical text columns to save memory
-df["primary_type"]        = df["primary_type"].astype("category")
-df["description"]         = df["description"].astype("category")
-df["location_description"] = df["location_description"].astype("category")
+    print(f"Saved cleaned dataset to {out_path} (rows: {len(cleaned)})")
+    return 0
 
-# Verify missing values did not increase after type conversions
-missing = df.isnull().sum()
-missing_pct = (missing / len(df) * 100).round(2)
-missing_summary = pd.DataFrame({
-    "missing_count": missing,
-    "missing_pct": missing_pct
-}).sort_values("missing_pct", ascending=False)
-missing_summary
 
-# ── Remove coordinates outside Chicago ───────────────────────────────────────
-
-# we first remove the location column: is redundant ('y-coordinate' and
-# 'x-coordinate' already have the same information).
-
-df = df.drop(columns=['location'])
-
-# ── Remove coordinates outside Chicago ───────────────────────────────────────
-# Valid Chicago latitude range: 41.6 - 42.1
-# Valid Chicago longitude range: -87.9 - -87.5
-print(f'Observations with invalid latitude coordinates: ',len(df[~df['latitude'].between(41.6, 42.1)]))
-print(f'Obsevations with null values in latitude coordinates: ',len(df[df['latitude'].isnull()]))
-print(f'Thus, observations with non-null values yet out-of-range latitude coordinates:',
-      len(df[~df['latitude'].between(41.6, 42.1)]) - len(df[df['latitude'].isnull()]))
-
-print(f'Observations with invalid longitude coordinates: ',len(df[~df['longitude'].between(-87.9, -87.5)]))
-print(f'Obsevations with null values in longitude coordinates: ',len(df[df['longitude'].isnull()]))
-print(f'Thus, observations with non-null values yet out-of-range longitude coordinates:',
-      len(df[~df['longitude'].between(-87.9, -87.5)]) - len(df[df['longitude'].isnull()]))
-
-# It would be safe to delete observations with null-values in either latitude or longitude.
-# Deleting 149 observations without valid latitude coordinates might be safe, but doing so
-# for 27759 observations without valid longitud coordinates might not. Further exploration
-# might be required before making a decision.
-
-# ── Missing data analysis ─────────────────────────────────────────────────────
-
-# Total rows with at least one missing value
-print("Rows with at least one missing value:", df.isnull().any(axis=1).sum())
-print("That is", round(df.isnull().any(axis=1).sum() / len(df) * 100, 2), "% of the data")
-
-# Which columns are driving the missing values
-print("\nMissing values per column for incomplete rows:")
-print(df[df.isnull().any(axis=1)][df.columns].isnull().sum())
-
-# ── Is missing data concentrated in certain years? ────────────────────────────
-df["has_missing"] = df.isnull().any(axis=1)
-
-missing_by_year = df.groupby("year")["has_missing"].agg(["sum", "count"])
-missing_by_year["pct"] = (missing_by_year["sum"] / missing_by_year["count"] * 100).round(2)
-missing_by_year.columns = ["missing_count", "total_rows", "missing_pct"]
-print(missing_by_year)
-# Note: 2001 has high missing data - worth considering in analysis
-
-# Which specific columns are missing by year
-df.groupby("year")[["latitude", "longitude", "ward", "community_area"]].apply(lambda x: x.isnull().sum())
-
-#double checking for things that may be considered full but just empty text, seems fine
-# ── Check for empty strings masquerading as non-null ─────────────────────────
-for col in df.select_dtypes(include="object").columns:
-    empty_count = (df[col].astype(str).str.strip() == "").sum()
-    nan_string  = (df[col].astype(str) == "nan").sum()
-    if empty_count > 0 or nan_string > 0:
-        print(col, "- empty strings:", empty_count, "| 'nan' strings:", nan_string)
-
-# ── Save cleaned data ─────────────────────────────────────────────────────────
-df = df.drop(columns=["has_missing"])
-
-CLEAN_DATA_PATH = 'data/cleaned/chicago_crimes_cleaned.csv'
-os.makedirs('data/cleaned', exist_ok=True)
-df.to_csv(CLEAN_DATA_PATH, index=False)
-print(f"Cleaned data saved to {CLEAN_DATA_PATH}")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,54 @@
+import unittest
+
+import pandas as pd
+
+from data.clean import preprocess
+
+
+class TestPreprocess(unittest.TestCase):
+    def test_drops_missing_lat_lon(self):
+        df = pd.DataFrame(
+            {
+                "date": ["2025-01-01T12:00:00.000", "2025-01-02T12:00:00.000"],
+                "latitude": [41.9, None],
+                "longitude": [-87.7, -87.7],
+                "primary_type": ["THEFT", "THEFT"],
+            }
+        )
+        out = preprocess(df)
+        self.assertEqual(len(out), 1)
+
+    def test_adds_temporal_features(self):
+        df = pd.DataFrame(
+            {
+                "date": ["2025-01-01T12:34:56.000"],
+                "latitude": [41.9],
+                "longitude": [-87.7],
+            }
+        )
+        out = preprocess(df)
+        self.assertIn("Year", out.columns)
+        self.assertIn("Month", out.columns)
+        self.assertIn("Day", out.columns)
+        self.assertIn("Hour", out.columns)
+        self.assertIn("Day of Week", out.columns)
+        self.assertEqual(int(out.iloc[0]["Year"]), 2025)
+        self.assertEqual(int(out.iloc[0]["Month"]), 1)
+        self.assertEqual(int(out.iloc[0]["Day"]), 1)
+        self.assertEqual(int(out.iloc[0]["Hour"]), 12)
+
+    def test_filters_out_2026_plus(self):
+        df = pd.DataFrame(
+            {
+                "date": ["2026-01-01T00:00:00.000"],
+                "latitude": [41.9],
+                "longitude": [-87.7],
+            }
+        )
+        out = preprocess(df)
+        self.assertEqual(len(out), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Adds `data/clean.py` as a reusable CLI-based preprocessing step
- Drops rows with missing `latitude`/`longitude`
- Extracts temporal features: `Year`, `Month`, `Day`, `Hour`, `Day of Week`
- Converts suitable columns to categorical (best preserved via Parquet output)
- Adds unit tests (`tests/test_preprocessing.py`)
- Updates README with a short codebook for the cleaned dataset

## How to test
- `python3 -m pip install pandas pyarrow`
- `python3 -m unittest discover -s tests -p "test*.py"`
- (with data) `python3 data/clean.py --format parquet`

Closes #49