### PR TITLE
Parquet distribution workflow (Issues #31, #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,33 @@ The datasets are not stored in this repository. To download them, follow these s
 2. uv sync
 3. python download_data.py
 
+### Parquet distribution (recommended)
+
+To ensure everyone uses the **same snapshot** (up to 31 Dec 2025) and to speed up loading, we distribute a cleaned **Parquet** file via the shared Google Drive.
+
+- **Download raw CSV snapshot**
+
+```bash
+python download_data.py
+```
+
+- **Download cleaned Parquet snapshot** (once the Drive file id is available)
+
+```bash
+export CHAGGG_CLEANED_PARQUET_FILE_ID="<drive-file-id>"
+python download_data.py --skip-raw
+```
+
+### Creating the Parquet file (for maintainers)
+
+Once `data/cleaned/chicago_crimes_cleaned.csv` exists locally:
+
+```bash
+python scripts/convert_cleaned_csv_to_parquet.py
+```
+
+Then upload `data/cleaned/chicago_crimes_cleaned.parquet` to the shared Drive and share the **file id** (to be used as `CHAGGG_CLEANED_PARQUET_FILE_ID`).
+
 ## Development Workflow
 
 To maintain code quality and ensure collaboration, please follow this workflow:

--- a/download_data.py
+++ b/download_data.py
@@ -1,29 +1,103 @@
-#this script automates the data download from google drive and creates a local data folder with the raw and cleaned data
+"""
+Download shared dataset snapshots from Google Drive.
 
+For team consistency, we distribute fixed snapshots (2001–2025) via Drive rather
+than downloading "up to today" from the live portal.
+
+Issue #31 / #33:
+- provide a fast Parquet option for consistent access across machines
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
+from pathlib import Path
+
 import gdown
 
-os.makedirs("data/raw", exist_ok=True)
-os.makedirs("data/processed", exist_ok=True)
 
-# Raw data
-RAW_FILE_ID = "1HGIQVus5LLVN8ONsKPhN6pX1ViHQdrdJ"
-RAW_OUTPUT = "data/raw/chicago_crimes_2001_2025_raw.csv"
+RAW_FILE_ID_DEFAULT = "1HGIQVus5LLVN8ONsKPhN6pX1ViHQdrdJ"
+RAW_OUTPUT_DEFAULT = "data/raw/chicago_crimes_2001_2025_raw.csv"
 
-if not os.path.exists(RAW_OUTPUT):
-    print("Downloading raw dataset...")
-    gdown.download(f"https://drive.google.com/uc?id={RAW_FILE_ID}", RAW_OUTPUT, quiet=False)
-    print("Done.")
-else:
-    print("Raw dataset already exists, skipping.")
+# Set this once the cleaned parquet is uploaded to the shared drive.
+# Can also be provided via env var CHAGGG_CLEANED_PARQUET_FILE_ID.
+CLEANED_PARQUET_FILE_ID_DEFAULT = None
+CLEANED_PARQUET_OUTPUT_DEFAULT = "data/cleaned/chicago_crimes_cleaned.parquet"
 
-# Processed data
-#PROCESSED_FILE_ID = "your_processed_file_id_here"
-#PROCESSED_OUTPUT = "data/chicago_crimes_2001_2025_cleaned.csv"
 
-#if not os.path.exists(PROCESSED_OUTPUT):
-    #print("Downloading processed dataset...")
-    #gdown.download(f"https://drive.google.com/uc?id={PROCESSED_FILE_ID}", PROCESSED_OUTPUT, quiet=False)
-    #print("Done.")
-#else:
-    #print("Processed dataset already exists, skipping.")
+def ensure_dirs() -> None:
+    Path("data/raw").mkdir(parents=True, exist_ok=True)
+    Path("data/cleaned").mkdir(parents=True, exist_ok=True)
+
+
+def download_drive_file(*, file_id: str, out_path: str, force: bool) -> None:
+    if os.path.exists(out_path) and not force:
+        print(f"File already exists at {out_path}, skipping.")
+        return
+    url = f"https://drive.google.com/uc?id={file_id}"
+    gdown.download(url, out_path, quiet=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Download shared dataset snapshots from Drive.")
+    parser.add_argument(
+        "--raw-file-id",
+        default=os.environ.get("CHAGGG_RAW_FILE_ID", RAW_FILE_ID_DEFAULT),
+        help="Google Drive file id for the raw CSV snapshot.",
+    )
+    parser.add_argument(
+        "--raw-out",
+        default=RAW_OUTPUT_DEFAULT,
+        help="Output path for the raw CSV.",
+    )
+    parser.add_argument(
+        "--cleaned-parquet-file-id",
+        default=os.environ.get("CHAGGG_CLEANED_PARQUET_FILE_ID", CLEANED_PARQUET_FILE_ID_DEFAULT),
+        help="Google Drive file id for the cleaned Parquet snapshot (optional).",
+    )
+    parser.add_argument(
+        "--cleaned-parquet-out",
+        default=CLEANED_PARQUET_OUTPUT_DEFAULT,
+        help="Output path for the cleaned Parquet.",
+    )
+    parser.add_argument(
+        "--skip-raw",
+        action="store_true",
+        help="Skip downloading the raw CSV snapshot.",
+    )
+    parser.add_argument(
+        "--skip-cleaned-parquet",
+        action="store_true",
+        help="Skip downloading the cleaned Parquet snapshot.",
+    )
+    parser.add_argument("--force", action="store_true", help="Re-download even if files exist.")
+    args = parser.parse_args()
+
+    ensure_dirs()
+
+    if not args.skip_raw:
+        print("Downloading raw dataset snapshot (CSV)...")
+        download_drive_file(file_id=args.raw_file_id, out_path=args.raw_out, force=args.force)
+        print("Done.")
+
+    if not args.skip_cleaned_parquet:
+        if not args.cleaned_parquet_file_id:
+            print(
+                "No cleaned parquet file id configured yet. "
+                "Set CHAGGG_CLEANED_PARQUET_FILE_ID or pass --cleaned-parquet-file-id."
+            )
+        else:
+            print("Downloading cleaned dataset snapshot (Parquet)...")
+            download_drive_file(
+                file_id=args.cleaned_parquet_file_id,
+                out_path=args.cleaned_parquet_out,
+                force=args.force,
+            )
+            print("Done.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/convert_cleaned_csv_to_parquet.py
+++ b/scripts/convert_cleaned_csv_to_parquet.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Convert cleaned CSV to Parquet for faster distribution.")
+    parser.add_argument(
+        "--in",
+        dest="in_path",
+        default="data/cleaned/chicago_crimes_cleaned.csv",
+        help="Input cleaned CSV path.",
+    )
+    parser.add_argument(
+        "--out",
+        dest="out_path",
+        default="data/cleaned/chicago_crimes_cleaned.parquet",
+        help="Output Parquet path.",
+    )
+    args = parser.parse_args()
+
+    in_path = Path(args.in_path)
+    out_path = Path(args.out_path)
+    if not in_path.exists():
+        raise SystemExit(f"Input CSV not found at {in_path}")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_csv(in_path, low_memory=False)
+    df.to_parquet(out_path, index=False)
+    print(f"Wrote {out_path} (rows: {len(df)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- Extends `download_data.py` to optionally download a shared cleaned Parquet snapshot from Google Drive
- Adds `scripts/convert_cleaned_csv_to_parquet.py` to generate the Parquet file from the cleaned CSV
- Updates README with a short Parquet distribution workflow and env var configuration

## How to test
- `python3 -m pip install gdown pandas pyarrow`
- `python3 download_data.py --help`
- `python3 download_data.py` (raw CSV snapshot)
- `export CHAGGG_CLEANED_PARQUET_FILE_ID=<drive-file-id> && python3 download_data.py --skip-raw` (cleaned Parquet snapshot)

Closes #31
Closes #33