### PR TITLE
Add location-only KNN baseline (sklearn) for arrest probability — ablation vs. from-scratch model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pytest>=9.0.3",
     "python-dotenv>=1.2.2",
     "requests>=2.32.5",
+    "scikit-learn>=1.6.0",
     "seaborn>=0.13.2",
 ]
 

--- a/scripts/knn_location_only.py
+++ b/scripts/knn_location_only.py
@@ -42,7 +42,7 @@ from typing import Iterable
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import UndefinedMetricWarning
-from sklearn.metrics import accuracy_score, log_loss
+from sklearn.metrics import accuracy_score, log_loss, roc_auc_score
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.preprocessing import StandardScaler
@@ -125,6 +125,7 @@ class CrimeTypeResult:
     best_k: int | None = None
     test_log_loss: float | None = None
     test_accuracy: float | None = None
+    test_roc_auc: float | None = None
     fit_seconds: float | None = None
     predictions: pd.DataFrame | None = field(default=None, repr=False)
 
@@ -147,6 +148,7 @@ class CrimeTypeResult:
                 "cv_neg_log_loss": self.cv_neg_log_loss,
                 "test_log_loss": self.test_log_loss,
                 "test_accuracy": self.test_accuracy,
+                "test_roc_auc": self.test_roc_auc,
                 "fit_seconds": self.fit_seconds,
             }
         )
@@ -259,6 +261,8 @@ def evaluate_crime_type(
         if p_arrest_idx is not None
         else np.zeros(len(y_test), dtype=float)
     )
+    if p_arrest_idx is not None and len(np.unique(y_test)) >= 2:
+        base.test_roc_auc = float(roc_auc_score(y_test, p_arrest))
 
     base.predictions = pd.DataFrame(
         {
@@ -472,6 +476,7 @@ def main(argv: list[str] | None = None) -> int:
                 "best_k": r.best_k,
                 "test_log_loss": r.test_log_loss,
                 "test_accuracy": r.test_accuracy,
+                "test_roc_auc": r.test_roc_auc,
                 "skipped": r.skipped,
             }
             for r in results
@@ -495,7 +500,13 @@ def main(argv: list[str] | None = None) -> int:
         eval_df_sorted = eval_df.sort_values("test_log_loss")
         print(
             eval_df_sorted[
-                ["crime_type", "best_k", "test_log_loss", "test_accuracy"]
+                [
+                    "crime_type",
+                    "best_k",
+                    "test_log_loss",
+                    "test_accuracy",
+                    "test_roc_auc",
+                ]
             ].to_string(index=False)
         )
     skipped_df = summary_df[~summary_df["skipped"].isna()]

--- a/scripts/knn_location_only.py
+++ b/scripts/knn_location_only.py
@@ -1,0 +1,510 @@
+"""
+Location-only KNN baseline (sklearn) for arrest probability prediction.
+
+This is the ablation baseline against the from-scratch KNN + local logistic
+regression pipeline in ``src/crime_knn.py``. For every crime ``primary_type``
+we fit ``sklearn.neighbors.KNeighborsClassifier`` on standardised
+``(latitude, longitude)`` features only, tune ``k`` via stratified CV on the
+training set (candidates: 10, 25, 50, 100, 250) and report test-set
+log-loss and accuracy.
+
+The from-scratch requirement does not apply here — sklearn is allowed for
+the comparison baseline.
+
+Dependency note (issue: location-only KNN comparison model)
+-----------------------------------------------------------
+This script is meant to share data preparation with the from-scratch model.
+Until @ght-1's "Train/test split + standardization" PR lands on ``main``,
+the helpers below (``split_train_test_by_year`` and the inline
+``StandardScaler`` step) replicate the expected behaviour. When that PR
+merges, swap those helpers for the shared utilities so both models consume
+identical training and test sets.
+
+Run from repo root (after cleaned data exists):
+
+.. code:: shell
+
+    PYTHONUNBUFFERED=1 uv run python scripts/knn_location_only.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+from sklearn.exceptions import UndefinedMetricWarning
+from sklearn.metrics import accuracy_score, log_loss
+from sklearn.model_selection import GridSearchCV, StratifiedKFold
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.preprocessing import StandardScaler
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_K_CANDIDATES: tuple[int, ...] = (10, 25, 50, 100, 250)
+DEFAULT_TRAIN_YEARS: tuple[int, int] = (2015, 2022)
+DEFAULT_TEST_YEARS: tuple[int, int] = (2023, 2024)
+
+
+# ---------------------------------------------------------------------------
+# Data preparation helpers
+# ---------------------------------------------------------------------------
+def split_train_test_by_year(
+    df: pd.DataFrame,
+    train_years: tuple[int, int] = DEFAULT_TRAIN_YEARS,
+    test_years: tuple[int, int] = DEFAULT_TEST_YEARS,
+    date_col: str = "date",
+    year_col: str = "year",
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Year-based train/test split.
+
+    Mirrors the convention used elsewhere in the project (DBSCAN hotspots,
+    KNN forecast). Replace this with @ght-1's shared splitter once that PR
+    is merged so the location-only baseline and the main model share an
+    identical split.
+    """
+    if year_col in df.columns:
+        year = pd.to_numeric(df[year_col], errors="coerce")
+    else:
+        year = pd.to_datetime(df[date_col], errors="coerce").dt.year
+
+    train_mask = year.between(train_years[0], train_years[1])
+    test_mask = year.between(test_years[0], test_years[1])
+    train = df.loc[train_mask].reset_index(drop=True)
+    test = df.loc[test_mask].reset_index(drop=True)
+    return train, test
+
+
+def standardize_locations(
+    train: pd.DataFrame,
+    test: pd.DataFrame,
+    feature_cols: tuple[str, str] = ("latitude", "longitude"),
+) -> tuple[np.ndarray, np.ndarray, StandardScaler]:
+    """Fit ``StandardScaler`` on train only, apply to both splits.
+
+    Replace with the shared standardisation helper once @ght-1's PR is
+    merged so the from-scratch model and this baseline share the exact
+    same scaler state.
+    """
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(train[list(feature_cols)].to_numpy(dtype=float))
+    X_test = scaler.transform(test[list(feature_cols)].to_numpy(dtype=float))
+    return X_train, X_test, scaler
+
+
+def slugify(name: str) -> str:
+    """Turn a crime ``primary_type`` into a safe filename component."""
+    s = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()
+    return s or "unnamed"
+
+
+# ---------------------------------------------------------------------------
+# Per-crime-type training + evaluation
+# ---------------------------------------------------------------------------
+@dataclass
+class CrimeTypeResult:
+    """Container for per-crime-type CV+test outcomes."""
+
+    crime_type: str
+    n_train: int
+    n_test: int
+    positive_rate_train: float
+    positive_rate_test: float
+    skipped: str | None = None
+    k_candidates: list[int] = field(default_factory=list)
+    cv_neg_log_loss: list[dict[str, float]] = field(default_factory=list)
+    best_k: int | None = None
+    test_log_loss: float | None = None
+    test_accuracy: float | None = None
+    fit_seconds: float | None = None
+    predictions: pd.DataFrame | None = field(default=None, repr=False)
+
+    def metrics_dict(self) -> dict[str, object]:
+        """Serialisable metrics (no DataFrame)."""
+        out: dict[str, object] = {
+            "crime_type": self.crime_type,
+            "n_train": self.n_train,
+            "n_test": self.n_test,
+            "positive_rate_train": self.positive_rate_train,
+            "positive_rate_test": self.positive_rate_test,
+        }
+        if self.skipped is not None:
+            out["skipped"] = self.skipped
+            return out
+        out.update(
+            {
+                "k_candidates": self.k_candidates,
+                "best_k": self.best_k,
+                "cv_neg_log_loss": self.cv_neg_log_loss,
+                "test_log_loss": self.test_log_loss,
+                "test_accuracy": self.test_accuracy,
+                "fit_seconds": self.fit_seconds,
+            }
+        )
+        return out
+
+
+def _valid_k_candidates(
+    candidates: Iterable[int], n_train: int, cv_folds: int
+) -> list[int]:
+    """Trim ``k`` candidates to those that fit inside a CV training fold."""
+    fold_size = (n_train * (cv_folds - 1)) // cv_folds
+    valid = sorted({int(k) for k in candidates if 1 <= int(k) <= max(fold_size, 1)})
+    if not valid:
+        # Fall back to the smallest candidate clipped to fold size.
+        smallest = max(min(int(k) for k in candidates), 1)
+        valid = [min(smallest, max(fold_size, 1))]
+    return valid
+
+
+def evaluate_crime_type(
+    crime_type: str,
+    train: pd.DataFrame,
+    test: pd.DataFrame,
+    k_candidates: Iterable[int] = DEFAULT_K_CANDIDATES,
+    cv_folds: int = 5,
+    random_state: int = 42,
+    feature_cols: tuple[str, str] = ("latitude", "longitude"),
+    target_col: str = "arrest",
+) -> CrimeTypeResult:
+    """Tune ``k`` on ``train`` via stratified CV, evaluate on ``test``.
+
+    Returns a :class:`CrimeTypeResult` with metrics and predictions. If the
+    crime type cannot be evaluated (e.g. single-class train/test, empty
+    splits) the ``skipped`` field explains why.
+    """
+    n_train = len(train)
+    n_test = len(test)
+
+    base = CrimeTypeResult(
+        crime_type=crime_type,
+        n_train=n_train,
+        n_test=n_test,
+        positive_rate_train=(
+            float(train[target_col].mean()) if n_train and target_col in train.columns else 0.0
+        ),
+        positive_rate_test=(
+            float(test[target_col].mean()) if n_test and target_col in test.columns else 0.0
+        ),
+    )
+
+    if n_train == 0 or n_test == 0:
+        base.skipped = "empty train or test split"
+        return base
+
+    y_train = train[target_col].to_numpy(dtype=int)
+    y_test = test[target_col].to_numpy(dtype=int)
+    if len(np.unique(y_train)) < 2:
+        base.skipped = "single-class training set"
+        return base
+    if len(np.unique(y_test)) < 2:
+        base.skipped = "single-class test set"
+        return base
+
+    X_train, X_test, _ = standardize_locations(train, test, feature_cols)
+
+    valid_k = _valid_k_candidates(k_candidates, n_train, cv_folds)
+    base.k_candidates = valid_k
+
+    cv = StratifiedKFold(n_splits=cv_folds, shuffle=True, random_state=random_state)
+    grid = GridSearchCV(
+        KNeighborsClassifier(weights="uniform"),
+        param_grid={"n_neighbors": valid_k},
+        scoring="neg_log_loss",
+        cv=cv,
+        n_jobs=-1,
+        refit=True,
+        error_score="raise",
+    )
+
+    t0 = time.time()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+        grid.fit(X_train, y_train)
+    fit_seconds = time.time() - t0
+
+    base.best_k = int(grid.best_params_["n_neighbors"])
+    base.fit_seconds = float(fit_seconds)
+    base.cv_neg_log_loss = [
+        {
+            "k": int(k_val),
+            "mean_neg_log_loss": float(mean),
+            "std_neg_log_loss": float(std),
+        }
+        for k_val, mean, std in zip(
+            grid.cv_results_["param_n_neighbors"],
+            grid.cv_results_["mean_test_score"],
+            grid.cv_results_["std_test_score"],
+            strict=True,
+        )
+    ]
+
+    classes = list(grid.classes_)
+    proba = grid.predict_proba(X_test)
+    base.test_log_loss = float(log_loss(y_test, proba, labels=classes))
+    base.test_accuracy = float(accuracy_score(y_test, grid.predict(X_test)))
+
+    p_arrest_idx = classes.index(1) if 1 in classes else None
+    p_arrest = (
+        proba[:, p_arrest_idx]
+        if p_arrest_idx is not None
+        else np.zeros(len(y_test), dtype=float)
+    )
+
+    base.predictions = pd.DataFrame(
+        {
+            "latitude": test[feature_cols[0]].to_numpy(dtype=float),
+            "longitude": test[feature_cols[1]].to_numpy(dtype=float),
+            "y_true": y_test,
+            "y_pred": grid.predict(X_test),
+            "p_arrest": p_arrest,
+        }
+    )
+    return base
+
+
+def evaluate_all_crime_types(
+    df: pd.DataFrame,
+    *,
+    train_years: tuple[int, int] = DEFAULT_TRAIN_YEARS,
+    test_years: tuple[int, int] = DEFAULT_TEST_YEARS,
+    k_candidates: Iterable[int] = DEFAULT_K_CANDIDATES,
+    cv_folds: int = 5,
+    random_state: int = 42,
+    crime_types: Iterable[str] | None = None,
+    max_rows_per_type: int = 0,
+    progress: bool = True,
+) -> list[CrimeTypeResult]:
+    """Run the per-crime-type pipeline across the full dataset."""
+    required = {"primary_type", "latitude", "longitude", "arrest"}
+    missing = required - set(df.columns)
+    if missing:
+        raise KeyError(f"Input data missing required columns: {sorted(missing)}")
+
+    train_full, test_full = split_train_test_by_year(
+        df, train_years=train_years, test_years=test_years
+    )
+
+    if crime_types is None:
+        types = sorted(df["primary_type"].dropna().unique().tolist())
+    else:
+        types = list(crime_types)
+
+    results: list[CrimeTypeResult] = []
+    for i, ct in enumerate(types, start=1):
+        ct_train = train_full[train_full["primary_type"] == ct]
+        ct_test = test_full[test_full["primary_type"] == ct]
+
+        if max_rows_per_type and len(ct_train) > max_rows_per_type:
+            ct_train = ct_train.sample(
+                n=max_rows_per_type, random_state=random_state
+            ).reset_index(drop=True)
+
+        if progress:
+            print(
+                f"[{i}/{len(types)}] {ct}: train={len(ct_train):,} test={len(ct_test):,}",
+                flush=True,
+            )
+
+        result = evaluate_crime_type(
+            crime_type=ct,
+            train=ct_train,
+            test=ct_test,
+            k_candidates=k_candidates,
+            cv_folds=cv_folds,
+            random_state=random_state,
+        )
+        if progress:
+            if result.skipped:
+                print(f"    skipped: {result.skipped}", flush=True)
+            else:
+                print(
+                    f"    best k={result.best_k} "
+                    f"log_loss={result.test_log_loss:.4f} "
+                    f"acc={result.test_accuracy:.4f} "
+                    f"({result.fit_seconds:.1f}s)",
+                    flush=True,
+                )
+        results.append(result)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_int_csv(text: str) -> list[int]:
+    return [int(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def _parse_year_pair(text: str) -> tuple[int, int]:
+    parts = [int(x.strip()) for x in text.split(",") if x.strip()]
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("expected '<start>,<end>' (e.g. 2015,2022)")
+    return parts[0], parts[1]
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Location-only KNN baseline (sklearn) for arrest probability"
+    )
+    parser.add_argument(
+        "--k-candidates",
+        type=_parse_int_csv,
+        default=list(DEFAULT_K_CANDIDATES),
+        help="Comma-separated candidate K values (default: 10,25,50,100,250)",
+    )
+    parser.add_argument(
+        "--cv-folds",
+        type=int,
+        default=5,
+        help="Number of stratified CV folds for tuning K (default: 5)",
+    )
+    parser.add_argument(
+        "--train-years",
+        type=_parse_year_pair,
+        default=DEFAULT_TRAIN_YEARS,
+        help="Train year range as 'start,end' (default: 2015,2022)",
+    )
+    parser.add_argument(
+        "--test-years",
+        type=_parse_year_pair,
+        default=DEFAULT_TEST_YEARS,
+        help="Test year range as 'start,end' (default: 2023,2024)",
+    )
+    parser.add_argument(
+        "--crime-types",
+        type=str,
+        default="",
+        help="Comma-separated subset of primary_type to evaluate (default: all)",
+    )
+    parser.add_argument(
+        "--max-rows-per-type",
+        type=int,
+        default=0,
+        help="Optional cap on training rows per crime type (0 = no cap)",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Random seed used for CV and any subsampling (default: 42)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=PROJECT_ROOT / "outputs" / "knn_location_only",
+        help="Output directory (default: outputs/knn_location_only)",
+    )
+    parser.add_argument(
+        "--no-write-predictions",
+        action="store_true",
+        help="Skip writing per-crime-type prediction CSVs",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_argparser().parse_args(argv)
+
+    from src.preprocess_data import preprocess_data
+
+    print("Loading + preprocessing data via src.preprocess_data.preprocess_data()…")
+    df = preprocess_data()
+    print(f"  rows after preprocessing: {len(df):,}")
+
+    crime_types = (
+        [s.strip() for s in args.crime_types.split(",") if s.strip()]
+        if args.crime_types
+        else None
+    )
+
+    results = evaluate_all_crime_types(
+        df,
+        train_years=tuple(args.train_years),
+        test_years=tuple(args.test_years),
+        k_candidates=args.k_candidates,
+        cv_folds=args.cv_folds,
+        random_state=args.random_state,
+        crime_types=crime_types,
+        max_rows_per_type=args.max_rows_per_type,
+        progress=True,
+    )
+
+    out_dir: Path = args.output_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_rows = [r.metrics_dict() for r in results]
+    metrics_payload = {
+        "run_config": {
+            "train_years": list(args.train_years),
+            "test_years": list(args.test_years),
+            "k_candidates": list(args.k_candidates),
+            "cv_folds": int(args.cv_folds),
+            "random_state": int(args.random_state),
+            "max_rows_per_type": int(args.max_rows_per_type),
+            "feature_cols": ["latitude", "longitude"],
+            "target_col": "arrest",
+            "model": "sklearn.neighbors.KNeighborsClassifier(weights='uniform')",
+        },
+        "per_crime_type": summary_rows,
+    }
+    (out_dir / "metrics.json").write_text(
+        json.dumps(metrics_payload, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+
+    summary_df = pd.DataFrame(
+        [
+            {
+                "crime_type": r.crime_type,
+                "n_train": r.n_train,
+                "n_test": r.n_test,
+                "positive_rate_train": r.positive_rate_train,
+                "positive_rate_test": r.positive_rate_test,
+                "best_k": r.best_k,
+                "test_log_loss": r.test_log_loss,
+                "test_accuracy": r.test_accuracy,
+                "skipped": r.skipped,
+            }
+            for r in results
+        ]
+    )
+    summary_df.to_csv(out_dir / "summary.csv", index=False)
+
+    if not args.no_write_predictions:
+        for r in results:
+            if r.predictions is None:
+                continue
+            r.predictions.to_csv(
+                out_dir / f"predictions_{slugify(r.crime_type)}.csv", index=False
+            )
+
+    print(f"\nSaved metrics: {out_dir / 'metrics.json'}")
+    print(f"Saved summary: {out_dir / 'summary.csv'}")
+    print("\nPer-crime-type test results:")
+    eval_df = summary_df[summary_df["skipped"].isna()].copy()
+    if len(eval_df):
+        eval_df_sorted = eval_df.sort_values("test_log_loss")
+        print(
+            eval_df_sorted[
+                ["crime_type", "best_k", "test_log_loss", "test_accuracy"]
+            ].to_string(index=False)
+        )
+    skipped_df = summary_df[~summary_df["skipped"].isna()]
+    if len(skipped_df):
+        print("\nSkipped crime types:")
+        print(skipped_df[["crime_type", "skipped"]].to_string(index=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/knn_location_only.py
+++ b/scripts/knn_location_only.py
@@ -6,19 +6,22 @@ regression pipeline in ``src/crime_knn.py``. For every crime ``primary_type``
 we fit ``sklearn.neighbors.KNeighborsClassifier`` on standardised
 ``(latitude, longitude)`` features only, tune ``k`` via stratified CV on the
 training set (candidates: 10, 25, 50, 100, 250) and report test-set
-log-loss and accuracy.
+log-loss, accuracy and ROC-AUC.
 
 The from-scratch requirement does not apply here — sklearn is allowed for
 the comparison baseline.
 
-Dependency note (issue: location-only KNN comparison model)
------------------------------------------------------------
-This script is meant to share data preparation with the from-scratch model.
-Until @ght-1's "Train/test split + standardization" PR lands on ``main``,
-the helpers below (``split_train_test_by_year`` and the inline
-``StandardScaler`` step) replicate the expected behaviour. When that PR
-merges, swap those helpers for the shared utilities so both models consume
-identical training and test sets.
+Shared data preparation
+-----------------------
+Per the issue, both models must share **identical** data preparation. We
+therefore reuse @ght-1's helpers from ``scripts.utils``:
+
+* ``temporal_split(df, date_col='date', train_end='2022-12-31')``
+* ``fit_scaler(X_train)`` -> (mean, std) with ``+1e-8`` numerical guard
+* ``apply_scaler(X, mean, std)`` -> standardised array
+
+so the splits and the scaler are byte-for-byte identical to whatever the
+main model evaluation uses.
 
 Run from repo root (after cleaned data exists):
 
@@ -45,60 +48,34 @@ from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.metrics import accuracy_score, log_loss, roc_auc_score
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.preprocessing import StandardScaler
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.utils import apply_scaler, fit_scaler, temporal_split  # noqa: E402
+
 DEFAULT_K_CANDIDATES: tuple[int, ...] = (10, 25, 50, 100, 250)
-DEFAULT_TRAIN_YEARS: tuple[int, int] = (2015, 2022)
-DEFAULT_TEST_YEARS: tuple[int, int] = (2023, 2024)
+DEFAULT_TRAIN_END: str = "2022-12-31"
 
 
 # ---------------------------------------------------------------------------
-# Data preparation helpers
+# Data preparation
 # ---------------------------------------------------------------------------
-def split_train_test_by_year(
-    df: pd.DataFrame,
-    train_years: tuple[int, int] = DEFAULT_TRAIN_YEARS,
-    test_years: tuple[int, int] = DEFAULT_TEST_YEARS,
-    date_col: str = "date",
-    year_col: str = "year",
-) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Year-based train/test split.
-
-    Mirrors the convention used elsewhere in the project (DBSCAN hotspots,
-    KNN forecast). Replace this with @ght-1's shared splitter once that PR
-    is merged so the location-only baseline and the main model share an
-    identical split.
-    """
-    if year_col in df.columns:
-        year = pd.to_numeric(df[year_col], errors="coerce")
-    else:
-        year = pd.to_datetime(df[date_col], errors="coerce").dt.year
-
-    train_mask = year.between(train_years[0], train_years[1])
-    test_mask = year.between(test_years[0], test_years[1])
-    train = df.loc[train_mask].reset_index(drop=True)
-    test = df.loc[test_mask].reset_index(drop=True)
-    return train, test
-
-
 def standardize_locations(
     train: pd.DataFrame,
     test: pd.DataFrame,
     feature_cols: tuple[str, str] = ("latitude", "longitude"),
-) -> tuple[np.ndarray, np.ndarray, StandardScaler]:
-    """Fit ``StandardScaler`` on train only, apply to both splits.
+) -> tuple[np.ndarray, np.ndarray, tuple[np.ndarray, np.ndarray]]:
+    """Standardise ``feature_cols`` using @ght-1's ``fit_scaler``/
+    ``apply_scaler`` from ``scripts.utils``, fit on train only.
 
-    Replace with the shared standardisation helper once @ght-1's PR is
-    merged so the from-scratch model and this baseline share the exact
-    same scaler state.
+    Returns ``(X_train_scaled, X_test_scaled, (mean, std))`` so callers can
+    apply the same transform to held-out queries.
     """
-    scaler = StandardScaler()
-    X_train = scaler.fit_transform(train[list(feature_cols)].to_numpy(dtype=float))
-    X_test = scaler.transform(test[list(feature_cols)].to_numpy(dtype=float))
-    return X_train, X_test, scaler
+    X_train = train[list(feature_cols)].to_numpy(dtype=float)
+    X_test = test[list(feature_cols)].to_numpy(dtype=float)
+    mean, std = fit_scaler(X_train)
+    return apply_scaler(X_train, mean, std), apply_scaler(X_test, mean, std), (mean, std)
 
 
 def slugify(name: str) -> str:
@@ -223,7 +200,7 @@ def evaluate_crime_type(
         param_grid={"n_neighbors": valid_k},
         scoring="neg_log_loss",
         cv=cv,
-        n_jobs=-1,
+        n_jobs=1,
         refit=True,
         error_score="raise",
     )
@@ -279,8 +256,8 @@ def evaluate_crime_type(
 def evaluate_all_crime_types(
     df: pd.DataFrame,
     *,
-    train_years: tuple[int, int] = DEFAULT_TRAIN_YEARS,
-    test_years: tuple[int, int] = DEFAULT_TEST_YEARS,
+    train_end: str = DEFAULT_TRAIN_END,
+    date_col: str = "date",
     k_candidates: Iterable[int] = DEFAULT_K_CANDIDATES,
     cv_folds: int = 5,
     random_state: int = 42,
@@ -288,15 +265,18 @@ def evaluate_all_crime_types(
     max_rows_per_type: int = 0,
     progress: bool = True,
 ) -> list[CrimeTypeResult]:
-    """Run the per-crime-type pipeline across the full dataset."""
-    required = {"primary_type", "latitude", "longitude", "arrest"}
+    """Run the per-crime-type pipeline across the full dataset.
+
+    Splits the input via ``scripts.utils.temporal_split`` (rows with
+    ``date_col <= train_end`` go to train, rest to test) so this baseline
+    consumes the exact same train/test as the from-scratch model.
+    """
+    required = {"primary_type", "latitude", "longitude", "arrest", date_col}
     missing = required - set(df.columns)
     if missing:
         raise KeyError(f"Input data missing required columns: {sorted(missing)}")
 
-    train_full, test_full = split_train_test_by_year(
-        df, train_years=train_years, test_years=test_years
-    )
+    train_full, test_full = temporal_split(df, date_col=date_col, train_end=train_end)
 
     if crime_types is None:
         types = sorted(df["primary_type"].dropna().unique().tolist())
@@ -349,13 +329,6 @@ def _parse_int_csv(text: str) -> list[int]:
     return [int(x.strip()) for x in text.split(",") if x.strip()]
 
 
-def _parse_year_pair(text: str) -> tuple[int, int]:
-    parts = [int(x.strip()) for x in text.split(",") if x.strip()]
-    if len(parts) != 2:
-        raise argparse.ArgumentTypeError("expected '<start>,<end>' (e.g. 2015,2022)")
-    return parts[0], parts[1]
-
-
 def build_argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Location-only KNN baseline (sklearn) for arrest probability"
@@ -373,16 +346,14 @@ def build_argparser() -> argparse.ArgumentParser:
         help="Number of stratified CV folds for tuning K (default: 5)",
     )
     parser.add_argument(
-        "--train-years",
-        type=_parse_year_pair,
-        default=DEFAULT_TRAIN_YEARS,
-        help="Train year range as 'start,end' (default: 2015,2022)",
-    )
-    parser.add_argument(
-        "--test-years",
-        type=_parse_year_pair,
-        default=DEFAULT_TEST_YEARS,
-        help="Test year range as 'start,end' (default: 2023,2024)",
+        "--train-end",
+        type=str,
+        default=DEFAULT_TRAIN_END,
+        help=(
+            "Inclusive train cutoff date (YYYY-MM-DD). Rows with date <= "
+            "train_end go to train, the rest to test. Default: 2022-12-31, "
+            "matching @ght-1's `temporal_split` default."
+        ),
     )
     parser.add_argument(
         "--crime-types",
@@ -433,8 +404,7 @@ def main(argv: list[str] | None = None) -> int:
 
     results = evaluate_all_crime_types(
         df,
-        train_years=tuple(args.train_years),
-        test_years=tuple(args.test_years),
+        train_end=args.train_end,
         k_candidates=args.k_candidates,
         cv_folds=args.cv_folds,
         random_state=args.random_state,
@@ -449,8 +419,7 @@ def main(argv: list[str] | None = None) -> int:
     summary_rows = [r.metrics_dict() for r in results]
     metrics_payload = {
         "run_config": {
-            "train_years": list(args.train_years),
-            "test_years": list(args.test_years),
+            "train_end": args.train_end,
             "k_candidates": list(args.k_candidates),
             "cv_folds": int(args.cv_folds),
             "random_state": int(args.random_state),
@@ -458,6 +427,11 @@ def main(argv: list[str] | None = None) -> int:
             "feature_cols": ["latitude", "longitude"],
             "target_col": "arrest",
             "model": "sklearn.neighbors.KNeighborsClassifier(weights='uniform')",
+            "shared_data_prep": {
+                "split": "scripts.utils.temporal_split",
+                "fit_scaler": "scripts.utils.fit_scaler",
+                "apply_scaler": "scripts.utils.apply_scaler",
+            },
         },
         "per_crime_type": summary_rows,
     }

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -83,6 +83,27 @@ def get_data_info():
         else:
             print(f"✗ {name:20s} {'(not found)':>10s}  {path}")
 
+def fit_scaler(X_train):
+    """Fit standardization parameters on training data.
+
+    Restored from @ght-1's commits cb7bd85 / c8ce03a, which were authored
+    against scripts/utils.py inside PR #105 but did not survive the merge
+    into main. Both the from-scratch model and the location-only KNN
+    baseline reuse these so they share identical data preparation.
+    """
+    mean = X_train.mean(axis=0)
+    std = X_train.std(axis=0) + 1e-8
+    return mean, std
+
+def apply_scaler(X, mean, std):
+    """Apply previously-fit standardization to data."""
+    return (X - mean) / std
+
+def temporal_split(df, date_col='date', train_end='2022-12-31'):
+    """Split into train (≤ train_end) and test (> train_end)."""
+    train_mask = df[date_col] <= train_end
+    return df[train_mask].reset_index(drop=True), df[~train_mask].reset_index(drop=True)
+
 if __name__ == "__main__":
     print("=" * 60)
     print("CHICAGO CRIME DATA UTILITIES")

--- a/tests/test_knn_location_only.py
+++ b/tests/test_knn_location_only.py
@@ -155,10 +155,12 @@ class TestEvaluateCrimeType(unittest.TestCase):
         self.assertIn(result.best_k, [5, 10, 25])
         self.assertIsNotNone(result.test_log_loss)
         self.assertIsNotNone(result.test_accuracy)
+        self.assertIsNotNone(result.test_roc_auc)
         # With well-separated, calibrated clusters, KNN must do better than
         # the pure positive-rate baseline of ~0.5 -> log(2) ≈ 0.693
         self.assertLess(result.test_log_loss, 0.55)
         self.assertGreater(result.test_accuracy, 0.7)
+        self.assertGreater(result.test_roc_auc, 0.85)
         self.assertEqual(len(result.cv_neg_log_loss), 3)
         self.assertIsNotNone(result.predictions)
         self.assertEqual(

--- a/tests/test_knn_location_only.py
+++ b/tests/test_knn_location_only.py
@@ -11,15 +11,14 @@ import pandas as pd
 
 from scripts.knn_location_only import (
     _parse_int_csv,
-    _parse_year_pair,
     _valid_k_candidates,
     evaluate_all_crime_types,
     evaluate_crime_type,
     main,
     slugify,
-    split_train_test_by_year,
     standardize_locations,
 )
+from scripts.utils import temporal_split
 
 
 def _make_two_cluster_df(
@@ -46,7 +45,6 @@ def _make_two_cluster_df(
             "latitude": np.concatenate([lat1, lat2]),
             "longitude": np.concatenate([lon1, lon2]),
             "arrest": np.concatenate([arr1, arr2]),
-            "year": years,
             "date": pd.to_datetime(
                 [f"{int(y)}-06-15" for y in years], errors="coerce"
             ),
@@ -73,59 +71,42 @@ class TestParseHelpers(unittest.TestCase):
         self.assertEqual(_parse_int_csv("10, 25 ,50,100, 250"), [10, 25, 50, 100, 250])
         self.assertEqual(_parse_int_csv(""), [])
 
-    def test_parse_year_pair(self):
-        self.assertEqual(_parse_year_pair("2015,2022"), (2015, 2022))
-        with self.assertRaises(Exception):
-            _parse_year_pair("2015")
 
+class TestSharedTemporalSplit(unittest.TestCase):
+    """Sanity tests proving we use @ght-1's temporal_split unchanged."""
 
-class TestSplitByYear(unittest.TestCase):
-    def test_year_column_used(self):
-        df = pd.DataFrame(
-            {
-                "year": [2015, 2018, 2022, 2023, 2024, 2025],
-                "value": [1, 2, 3, 4, 5, 6],
-            }
-        )
-        train, test = split_train_test_by_year(df, train_years=(2015, 2022), test_years=(2023, 2024))
-        self.assertEqual(train["value"].tolist(), [1, 2, 3])
-        self.assertEqual(test["value"].tolist(), [4, 5])
-
-    def test_falls_back_to_date(self):
+    def test_temporal_split_uses_train_end_inclusive(self):
         df = pd.DataFrame(
             {
                 "date": pd.to_datetime(
-                    ["2015-01-01", "2023-06-01", "2030-01-01"], errors="coerce"
+                    [
+                        "2022-12-31",
+                        "2023-01-01",
+                        "2024-06-15",
+                        "2015-06-15",
+                    ]
                 ),
-                "value": [1, 2, 3],
+                "value": [1, 2, 3, 4],
             }
         )
-        train, test = split_train_test_by_year(df)
-        self.assertEqual(train["value"].tolist(), [1])
-        self.assertEqual(test["value"].tolist(), [2])
-
-    def test_handles_invalid_date_strings(self):
-        df = pd.DataFrame(
-            {
-                "date": ["2015-01-01", "not-a-date", "2024-12-31"],
-                "value": [1, 2, 3],
-            }
-        )
-        train, test = split_train_test_by_year(df)
-        self.assertEqual(train["value"].tolist(), [1])
-        self.assertEqual(test["value"].tolist(), [3])
+        train, test = temporal_split(df, date_col="date", train_end="2022-12-31")
+        self.assertEqual(sorted(train["value"].tolist()), [1, 4])
+        self.assertEqual(sorted(test["value"].tolist()), [2, 3])
 
 
 class TestStandardize(unittest.TestCase):
-    def test_train_only_fit(self):
+    def test_train_only_fit_matches_ght_helpers(self):
         train = pd.DataFrame({"latitude": [0.0, 2.0, 4.0], "longitude": [10.0, 12.0, 14.0]})
         test = pd.DataFrame({"latitude": [2.0], "longitude": [12.0]})
-        X_train, X_test, scaler = standardize_locations(train, test)
-        self.assertAlmostEqual(float(np.mean(X_train[:, 0])), 0.0, places=9)
-        self.assertAlmostEqual(float(np.std(X_train[:, 0])), 1.0, places=6)
+        X_train, X_test, (mean, std) = standardize_locations(train, test)
+        np.testing.assert_allclose(mean, [2.0, 12.0], atol=1e-9)
+        # @ght-1's fit_scaler adds 1e-8 to std (vs StandardScaler) for stability
+        self.assertAlmostEqual(float(std[0]), train["latitude"].std(ddof=0) + 1e-8, places=9)
         # Test point at training mean must map to ~0 after transform
         self.assertAlmostEqual(float(X_test[0, 0]), 0.0, places=6)
         self.assertAlmostEqual(float(X_test[0, 1]), 0.0, places=6)
+        # Train should be (approximately) zero-mean after transform
+        self.assertAlmostEqual(float(np.mean(X_train[:, 0])), 0.0, places=9)
 
 
 class TestValidKCandidates(unittest.TestCase):
@@ -142,7 +123,7 @@ class TestValidKCandidates(unittest.TestCase):
 class TestEvaluateCrimeType(unittest.TestCase):
     def test_well_separated_clusters_yield_low_log_loss(self):
         df = _make_two_cluster_df(n_per_cluster=300, seed=0)
-        train, test = split_train_test_by_year(df)
+        train, test = temporal_split(df, date_col="date", train_end="2022-12-31")
         result = evaluate_crime_type(
             crime_type="THEFT",
             train=train,
@@ -175,10 +156,19 @@ class TestEvaluateCrimeType(unittest.TestCase):
                 "latitude": [41.0, 41.1, 41.2, 41.3, 41.4, 41.5],
                 "longitude": [-87.0, -87.1, -87.2, -87.3, -87.4, -87.5],
                 "arrest": [0, 0, 0, 0, 1, 1],
-                "year": [2015, 2016, 2017, 2018, 2023, 2024],
+                "date": pd.to_datetime(
+                    [
+                        "2015-01-01",
+                        "2016-01-01",
+                        "2017-01-01",
+                        "2018-01-01",
+                        "2023-01-01",
+                        "2024-01-01",
+                    ]
+                ),
             }
         )
-        train, test = split_train_test_by_year(df)
+        train, test = temporal_split(df, date_col="date", train_end="2022-12-31")
         result = evaluate_crime_type("THEFT", train=train, test=test, cv_folds=2)
         self.assertEqual(result.skipped, "single-class training set")
         self.assertIsNone(result.test_log_loss)
@@ -190,10 +180,17 @@ class TestEvaluateCrimeType(unittest.TestCase):
                 "latitude": [41.0, 41.1, 41.2, 41.3],
                 "longitude": [-87.0, -87.1, -87.2, -87.3],
                 "arrest": [0, 1, 0, 1],
-                "year": [2015, 2016, 2017, 2018],
+                "date": pd.to_datetime(
+                    [
+                        "2015-01-01",
+                        "2016-01-01",
+                        "2017-01-01",
+                        "2018-01-01",
+                    ]
+                ),
             }
         )
-        train, test = split_train_test_by_year(df)
+        train, test = temporal_split(df, date_col="date", train_end="2022-12-31")
         result = evaluate_crime_type("THEFT", train=train, test=test, cv_folds=2)
         self.assertEqual(result.skipped, "empty train or test split")
 
@@ -258,6 +255,11 @@ class TestMainIntegration(unittest.TestCase):
             payload = json.loads((out_dir / "metrics.json").read_text())
             self.assertIn("run_config", payload)
             self.assertEqual(payload["run_config"]["k_candidates"], [5, 10])
+            self.assertEqual(payload["run_config"]["train_end"], "2022-12-31")
+            self.assertEqual(
+                payload["run_config"]["shared_data_prep"]["split"],
+                "scripts.utils.temporal_split",
+            )
             self.assertEqual(len(payload["per_crime_type"]), 1)
             self.assertEqual(payload["per_crime_type"][0]["crime_type"], "THEFT")
             self.assertIsNone(payload["per_crime_type"][0].get("skipped"))

--- a/tests/test_knn_location_only.py
+++ b/tests/test_knn_location_only.py
@@ -1,0 +1,265 @@
+"""Unit tests for scripts.knn_location_only."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from scripts.knn_location_only import (
+    _parse_int_csv,
+    _parse_year_pair,
+    _valid_k_candidates,
+    evaluate_all_crime_types,
+    evaluate_crime_type,
+    main,
+    slugify,
+    split_train_test_by_year,
+    standardize_locations,
+)
+
+
+def _make_two_cluster_df(
+    n_per_cluster: int = 200, seed: int = 0
+) -> pd.DataFrame:
+    """Two well-separated lat/lon clusters with distinct arrest rates.
+
+    Cluster 1 (around 41.85, -87.65) has high arrest probability (0.9).
+    Cluster 2 (around 41.95, -87.75) has low  arrest probability (0.1).
+    A KNN classifier on location alone should easily separate them.
+    """
+    rng = np.random.default_rng(seed)
+    lat1 = 41.85 + rng.normal(0, 0.005, n_per_cluster)
+    lon1 = -87.65 + rng.normal(0, 0.005, n_per_cluster)
+    arr1 = (rng.random(n_per_cluster) < 0.9).astype(int)
+    lat2 = 41.95 + rng.normal(0, 0.005, n_per_cluster)
+    lon2 = -87.75 + rng.normal(0, 0.005, n_per_cluster)
+    arr2 = (rng.random(n_per_cluster) < 0.1).astype(int)
+    n = 2 * n_per_cluster
+    years = rng.choice([2015, 2018, 2021, 2023, 2024], size=n)
+    return pd.DataFrame(
+        {
+            "primary_type": ["THEFT"] * n,
+            "latitude": np.concatenate([lat1, lat2]),
+            "longitude": np.concatenate([lon1, lon2]),
+            "arrest": np.concatenate([arr1, arr2]),
+            "year": years,
+            "date": pd.to_datetime(
+                [f"{int(y)}-06-15" for y in years], errors="coerce"
+            ),
+        }
+    )
+
+
+class TestSlugify(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(slugify("THEFT"), "theft")
+
+    def test_punctuation_collapsed(self):
+        self.assertEqual(
+            slugify("CRIMINAL DAMAGE / VANDALISM"), "criminal_damage_vandalism"
+        )
+
+    def test_empty_falls_back(self):
+        self.assertEqual(slugify("---"), "unnamed")
+        self.assertEqual(slugify(""), "unnamed")
+
+
+class TestParseHelpers(unittest.TestCase):
+    def test_parse_int_csv(self):
+        self.assertEqual(_parse_int_csv("10, 25 ,50,100, 250"), [10, 25, 50, 100, 250])
+        self.assertEqual(_parse_int_csv(""), [])
+
+    def test_parse_year_pair(self):
+        self.assertEqual(_parse_year_pair("2015,2022"), (2015, 2022))
+        with self.assertRaises(Exception):
+            _parse_year_pair("2015")
+
+
+class TestSplitByYear(unittest.TestCase):
+    def test_year_column_used(self):
+        df = pd.DataFrame(
+            {
+                "year": [2015, 2018, 2022, 2023, 2024, 2025],
+                "value": [1, 2, 3, 4, 5, 6],
+            }
+        )
+        train, test = split_train_test_by_year(df, train_years=(2015, 2022), test_years=(2023, 2024))
+        self.assertEqual(train["value"].tolist(), [1, 2, 3])
+        self.assertEqual(test["value"].tolist(), [4, 5])
+
+    def test_falls_back_to_date(self):
+        df = pd.DataFrame(
+            {
+                "date": pd.to_datetime(
+                    ["2015-01-01", "2023-06-01", "2030-01-01"], errors="coerce"
+                ),
+                "value": [1, 2, 3],
+            }
+        )
+        train, test = split_train_test_by_year(df)
+        self.assertEqual(train["value"].tolist(), [1])
+        self.assertEqual(test["value"].tolist(), [2])
+
+    def test_handles_invalid_date_strings(self):
+        df = pd.DataFrame(
+            {
+                "date": ["2015-01-01", "not-a-date", "2024-12-31"],
+                "value": [1, 2, 3],
+            }
+        )
+        train, test = split_train_test_by_year(df)
+        self.assertEqual(train["value"].tolist(), [1])
+        self.assertEqual(test["value"].tolist(), [3])
+
+
+class TestStandardize(unittest.TestCase):
+    def test_train_only_fit(self):
+        train = pd.DataFrame({"latitude": [0.0, 2.0, 4.0], "longitude": [10.0, 12.0, 14.0]})
+        test = pd.DataFrame({"latitude": [2.0], "longitude": [12.0]})
+        X_train, X_test, scaler = standardize_locations(train, test)
+        self.assertAlmostEqual(float(np.mean(X_train[:, 0])), 0.0, places=9)
+        self.assertAlmostEqual(float(np.std(X_train[:, 0])), 1.0, places=6)
+        # Test point at training mean must map to ~0 after transform
+        self.assertAlmostEqual(float(X_test[0, 0]), 0.0, places=6)
+        self.assertAlmostEqual(float(X_test[0, 1]), 0.0, places=6)
+
+
+class TestValidKCandidates(unittest.TestCase):
+    def test_caps_to_fold_training_size(self):
+        # 5-fold on n=100 -> training fold size 80
+        valid = _valid_k_candidates([10, 25, 50, 100, 250], n_train=100, cv_folds=5)
+        self.assertEqual(valid, [10, 25, 50])
+
+    def test_falls_back_when_all_too_large(self):
+        valid = _valid_k_candidates([100, 250], n_train=10, cv_folds=5)
+        self.assertEqual(valid, [8])  # min(100, fold_size=8)
+
+
+class TestEvaluateCrimeType(unittest.TestCase):
+    def test_well_separated_clusters_yield_low_log_loss(self):
+        df = _make_two_cluster_df(n_per_cluster=300, seed=0)
+        train, test = split_train_test_by_year(df)
+        result = evaluate_crime_type(
+            crime_type="THEFT",
+            train=train,
+            test=test,
+            k_candidates=[5, 10, 25],
+            cv_folds=3,
+            random_state=0,
+        )
+        self.assertIsNone(result.skipped)
+        self.assertIn(result.best_k, [5, 10, 25])
+        self.assertIsNotNone(result.test_log_loss)
+        self.assertIsNotNone(result.test_accuracy)
+        # With well-separated, calibrated clusters, KNN must do better than
+        # the pure positive-rate baseline of ~0.5 -> log(2) ≈ 0.693
+        self.assertLess(result.test_log_loss, 0.55)
+        self.assertGreater(result.test_accuracy, 0.7)
+        self.assertEqual(len(result.cv_neg_log_loss), 3)
+        self.assertIsNotNone(result.predictions)
+        self.assertEqual(
+            sorted(result.predictions.columns.tolist()),
+            sorted(["latitude", "longitude", "y_true", "y_pred", "p_arrest"]),
+        )
+
+    def test_skipped_on_single_class_train(self):
+        df = pd.DataFrame(
+            {
+                "primary_type": ["THEFT"] * 6,
+                "latitude": [41.0, 41.1, 41.2, 41.3, 41.4, 41.5],
+                "longitude": [-87.0, -87.1, -87.2, -87.3, -87.4, -87.5],
+                "arrest": [0, 0, 0, 0, 1, 1],
+                "year": [2015, 2016, 2017, 2018, 2023, 2024],
+            }
+        )
+        train, test = split_train_test_by_year(df)
+        result = evaluate_crime_type("THEFT", train=train, test=test, cv_folds=2)
+        self.assertEqual(result.skipped, "single-class training set")
+        self.assertIsNone(result.test_log_loss)
+
+    def test_skipped_on_empty_test(self):
+        df = pd.DataFrame(
+            {
+                "primary_type": ["THEFT"] * 4,
+                "latitude": [41.0, 41.1, 41.2, 41.3],
+                "longitude": [-87.0, -87.1, -87.2, -87.3],
+                "arrest": [0, 1, 0, 1],
+                "year": [2015, 2016, 2017, 2018],
+            }
+        )
+        train, test = split_train_test_by_year(df)
+        result = evaluate_crime_type("THEFT", train=train, test=test, cv_folds=2)
+        self.assertEqual(result.skipped, "empty train or test split")
+
+
+class TestEvaluateAllCrimeTypes(unittest.TestCase):
+    def test_runs_for_multiple_types(self):
+        a = _make_two_cluster_df(n_per_cluster=120, seed=1)
+        a["primary_type"] = "THEFT"
+        b = _make_two_cluster_df(n_per_cluster=120, seed=2)
+        b["primary_type"] = "ASSAULT"
+        df = pd.concat([a, b], ignore_index=True)
+
+        results = evaluate_all_crime_types(
+            df,
+            k_candidates=[5, 10],
+            cv_folds=3,
+            random_state=0,
+            progress=False,
+        )
+        self.assertEqual(sorted(r.crime_type for r in results), ["ASSAULT", "THEFT"])
+        for r in results:
+            self.assertIsNone(r.skipped)
+            self.assertIsNotNone(r.test_log_loss)
+
+    def test_missing_columns_raises(self):
+        df = pd.DataFrame({"latitude": [1.0], "longitude": [2.0]})
+        with self.assertRaises(KeyError):
+            evaluate_all_crime_types(df, progress=False)
+
+
+class TestMainIntegration(unittest.TestCase):
+    def test_main_writes_outputs(self):
+        import tempfile
+        from unittest import mock
+
+        df = _make_two_cluster_df(n_per_cluster=150, seed=3)
+        df["primary_type"] = "THEFT"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "out"
+            with mock.patch(
+                "src.preprocess_data.preprocess_data", return_value=df, create=True
+            ):
+                exit_code = main(
+                    [
+                        "--k-candidates",
+                        "5,10",
+                        "--cv-folds",
+                        "3",
+                        "--output-dir",
+                        str(out_dir),
+                        "--random-state",
+                        "0",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((out_dir / "metrics.json").exists())
+            self.assertTrue((out_dir / "summary.csv").exists())
+            self.assertTrue((out_dir / "predictions_theft.csv").exists())
+
+            payload = json.loads((out_dir / "metrics.json").read_text())
+            self.assertIn("run_config", payload)
+            self.assertEqual(payload["run_config"]["k_candidates"], [5, 10])
+            self.assertEqual(len(payload["per_crime_type"]), 1)
+            self.assertEqual(payload["per_crime_type"][0]["crime_type"], "THEFT")
+            self.assertIsNone(payload["per_crime_type"][0].get("skipped"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1427,6 +1427,7 @@ dependencies = [
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "scikit-learn" },
     { name = "seaborn" },
 ]
 
@@ -1450,6 +1451,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "scikit-learn", specifier = ">=1.6.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
 ]
 


### PR DESCRIPTION
Closes #<104>  <!-- replace with the actual issue number -->

## Summary

Implements the location-only KNN ablation baseline against the from-scratch
KNN + local logistic regression in `src/crime_knn.py`. Uses **only**
standardised `(latitude, longitude)` so we can quantify how much the
temporal cyclic features actually contribute on top.

sklearn is allowed for this baseline per the issue spec; the from-scratch
requirement only applies to the main model.

## What's in this PR

### `scripts/knn_location_only.py` (new)
- `sklearn.neighbors.KNeighborsClassifier` with classic majority vote
  (`weights="uniform"`) — no logistic regression on top
- Per `primary_type`:
  - 5-fold `StratifiedKFold` CV on the train split over
    `k ∈ [10, 25, 50, 100, 250]`, picks best by `neg_log_loss`
  - refits best k on full train, scores on test set
- Reports per crime type:
  - `test_log_loss`
  - `test_accuracy`
  - `test_roc_auc`
  - per-incident `predict_proba` for downstream comparison
- Outputs:
  - `outputs/knn_location_only/metrics.json` (full CV + test metrics + run config)
  - `outputs/knn_location_only/summary.csv` (one row per crime type)
  - `outputs/knn_location_only/predictions_<crime>.csv`
- CLI: `--k-candidates`, `--cv-folds`, `--train-end`, `--crime-types`,
  `--max-rows-per-type`, `--random-state`, `--output-dir`,
  `--no-write-predictions`

### `scripts/utils.py` — restored @ght-1's shared data prep helpers
The issue says **"both models share identical data preparation"**.
@ght-1 wrote those helpers in commits `cb7bd85` and `c8ce03a`
(`fit_scaler`, `apply_scaler`, `temporal_split`) targeting `scripts/utils.py`
inside PR #105. Tracing shows the commits are reachable from `origin/main`,
but the file changes did **not** survive PR #105's merge — the helpers
are missing from main's `scripts/utils.py`.

This PR restores them verbatim from @ght-1's commits with attribution,
so this baseline (and any future evaluation script for the from-scratch
model) consume the **exact same** split + scaler.

### `tests/test_knn_location_only.py` (new)
14 unit tests:
- `slugify`, `_parse_int_csv`, `_valid_k_candidates`
- `temporal_split` sanity check (≤ train_end inclusive)
- `standardize_locations` asserts the `+1e-8` numerical guard @ght-1
  baked into `fit_scaler`
- per-crime-type pipeline on synthetic two-cluster data
  (asserts `log_loss < 0.55`, `accuracy > 0.7`, `roc_auc > 0.85`)
- multi-type pipeline
- end-to-end CLI integration via `tempfile` + mocked `preprocess_data`

### `pyproject.toml` / `uv.lock`
- add `scikit-learn>=1.6.0`

## Issue checklist

- [x] Create `scripts/knn_location_only.py`
- [x] `KNeighborsClassifier` with classic majority vote (no local regression)
- [x] Tune k per crime type via CV on training set, candidates `[10, 25, 50, 100, 250]`
- [x] Output predicted probabilities (saved per incident in CSV)
- [x] Report log-loss and accuracy on test set, per crime type
      (also ROC-AUC, since the issue mentions "log-loss / AUC")
- [x] Train/test split + standardisation: shared via `scripts.utils.temporal_split`
      / `fit_scaler` / `apply_scaler` (restored from @ght-1's commits)

## Test plan

- [x] `uv run pytest tests/test_knn_location_only.py` → 14/14 passed
- [x] `uv run pytest tests/` → 53 passed, 6 subtests passed (full suite green)
- [ ] End-to-end on cleaned data:
      `uv run python scripts/knn_location_only.py`
- [ ] Compare per-crime-type `test_log_loss` / `test_accuracy` / `test_roc_auc`
      against the from-scratch KNN + local logistic regression to quantify
      the ablation gap

## Coordination

- The shared helpers in `scripts/utils.py` are byte-for-byte copies of
  @ght-1's original code. **Please confirm**, @ght-1, that this is what you
  intended to land in PR #105 — if you'd rather refine them, this PR can
  follow up.
- @YuriIrrgang's open PR #111 (`feature_data_bundles_per_crime_type_yuri`)
  uses an inline mean/std bundle baked into `.npz` files at training time;
  it does not split train/test. Once both PRs land we can converge on a
  single source of truth for standardisation.

cc: @ght-1, @YuriIrrgang, @wangrgrace
