### PR TITLE
feat: dashboard integration - restyle data dashboard to match terminal-forensic design system

### DIFF
--- a/src/flask_app/templates/dashboards/_space_content.html
+++ b/src/flask_app/templates/dashboards/_space_content.html
@@ -12,25 +12,125 @@
   #map { height: 100%; width: 100%; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
   .year-control {
     position: absolute; top: 10px; right: 10px;
-    background: rgba(15,20,25,0.9); padding: 10px 14px;
-    border-radius: 6px; box-shadow: 0 1px 4px rgba(0,0,0,0.4);
-    font: 13px/1.6 'DM Sans', sans-serif; color: #e2e8f0;
-    z-index: 1000; width: 320px;
+    background: rgba(20, 30, 40, 0.92);
+    border: 1px solid rgba(90, 155, 110, 0.3);
+    padding: 12px 16px;
+    border-radius: 4px;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.5);
+    font-family: 'Courier New', monospace;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #e6edf3;
+    z-index: 1000;
+    width: 320px;
   }
-  .year-control label { display: block; text-align: center; margin-bottom: 6px; font-weight: 600; }
-  .year-control #yearValue { color: #3b82f6; font-size: 14px; }
-  .year-control input[type=range] { width: 100%; }
+  .year-control label {
+    display: block;
+    text-align: center;
+    margin-bottom: 8px;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    color: #5a9b6e;
+  }
+  .year-control #yearValue {
+    color: #a0ff8c;
+    font-size: 15px;
+    font-weight: 700;
+    margin-left: 4px;
+  }
+  .year-control input[type=range] {
+    width: 100%;
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    background: rgba(90, 155, 110, 0.25);
+    border-radius: 2px;
+    outline: none;
+    cursor: pointer;
+  }
+  .year-control input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    background: #5a9b6e;
+    border: 2px solid #a0ff8c;
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: 0 0 8px rgba(160, 255, 140, 0.5);
+    transition: transform 0.15s;
+  }
+  .year-control input[type=range]::-webkit-slider-thumb:hover {
+    transform: scale(1.15);
+  }
+  .year-control input[type=range]::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    background: #5a9b6e;
+    border: 2px solid #a0ff8c;
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: 0 0 8px rgba(160, 255, 140, 0.5);
+  }
   .legend {
-    background: rgba(15,20,25,0.9); padding: 10px 14px;
-    border-radius: 6px; box-shadow: 0 1px 4px rgba(0,0,0,0.4);
-    font: 13px/1.6 'DM Sans', sans-serif; color: #e2e8f0;
+    background: rgba(20, 30, 40, 0.92);
+    border: 1px solid rgba(90, 155, 110, 0.3);
+    border-radius: 4px;
+    padding: 12px 14px;
+    font-family: 'Courier New', monospace;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #e6edf3;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.5);
   }
-  .legend h4 { margin: 0 0 6px; font-size: 13px; }
-  .legend i { display: inline-block; width: 18px; height: 10px; margin-right: 6px; border-radius: 2px; }
+  .legend h4 {
+    margin: 0 0 8px;
+    color: #5a9b6e;
+    font-size: 13px;
+    letter-spacing: 0.15em;
+    font-weight: 700;
+  }
+  .legend i {
+    display: inline-block;
+    width: 18px;
+    height: 10px;
+    margin-right: 6px;
+    border-radius: 2px;
+  }
   .leaflet-popup-content-wrapper { background: #1a2332; color: #e2e8f0; border-radius: 6px; }
   .leaflet-popup-tip { background: #1a2332; }
   .leaflet-popup-content { font-family: 'DM Sans', sans-serif; }
   .leaflet-popup-content hr { border-color: #334155; }
+  .cluster-mark {
+      background: rgba(20, 30, 40, 0.85);
+      border: 2px solid #5a9b6e;
+      border-radius: 50%;
+      width: 40px !important;
+      height: 40px !important;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #ffffff;
+      font-family: 'Courier New', monospace;
+      font-weight: 700;
+      font-size: 12px;
+      letter-spacing: 0.02em;
+      box-shadow: 0 0 8px rgba(90, 155, 110, 0.4);
+    }
+    .cluster-mark span {
+      line-height: 1;
+    }
+    .cluster-mark div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+    }
 </style>
 
 <div class="map-wrapper">
@@ -67,7 +167,16 @@
     const points = pointsByYear[year] || [];
     const stats = statsByYear[year] || {};
 
-    clusterLayer = L.markerClusterGroup();
+    clusterLayer = L.markerClusterGroup({
+      iconCreateFunction: function(cluster) {
+        const count = cluster.getChildCount();
+        return L.divIcon({
+          html: '<div><span>' + count + '</span></div>',
+          className: 'cluster-mark',
+          iconSize: L.point(40, 40)
+        });
+      }
+    });;
     points.forEach(([lat, lon, type]) => {
       const m = L.circleMarker([lat, lon], { radius: 3, color: '#e74c3c', fillOpacity: 0.6, weight: 0 });
       m.bindPopup(type);
@@ -77,10 +186,15 @@
 
     const heatData = points.map(([lat, lon]) => [lat, lon, 0.4]);
     heatLayer = L.heatLayer(heatData, {
-      radius: 12, blur: 18, maxZoom: 15, minOpacity: 0.03, max: 1.0,
-      gradient: { 0.0: 'rgba(0,0,0,0)', 0.2: 'rgba(26,152,80,0.4)', 0.35: 'rgba(145,207,96,0.5)',
-                  0.5: 'rgba(217,239,139,0.5)', 0.65: 'rgba(254,224,139,0.5)',
-                  0.8: 'rgba(252,141,89,0.6)', 0.95: 'rgba(215,48,39,0.7)', 1.0: 'rgba(165,0,38,0.8)' }
+      radius: 8, blur: 4, maxZoom: 15, minOpacity: 0.05, max: 0.5,
+      gradient: {
+        0.0:  'rgba(20, 60, 35, 0)',       // transparent dark green
+        0.15: 'rgba(20, 60, 35, 0.6)',     // dark forest green (low)
+        0.35: 'rgba(30, 100, 50, 0.7)',    // deep green
+        0.55: 'rgba(50, 150, 70, 0.8)',    // medium green
+        0.75: 'rgba(90, 200, 100, 0.88)',  // bright green
+        1.0:  'rgba(160, 255, 140, 0.95)'  // luminous pale green (peak)
+      }
     }).addTo(map);
 
     boundaryLayer = L.geoJSON(geojsonData, {
@@ -127,13 +241,12 @@
     const legend = L.control({ position: 'bottomright' });
     legend.onAdd = () => {
       const div = L.DomUtil.create('div', 'legend');
-      div.innerHTML = `<h4>Crime Density</h4>
-        <div><i style="background:#1a9850"></i>Low</div>
-        <div><i style="background:#d9ef8b"></i>Medium-Low</div>
-        <div><i style="background:#fee08b"></i>Medium</div>
-        <div><i style="background:#fc8d59"></i>Medium-High</div>
-        <div><i style="background:#d73027"></i>High</div>
-        <div><i style="background:#a50026"></i>Very High</div>`;
+      div.innerHTML = `<h4>// Crime Density</h4>
+        <div><i style="background:#143c23"></i>Low</div>
+        <div><i style="background:#1e6432"></i>Mid-Low</div>
+        <div><i style="background:#329646"></i>Mid</div>
+        <div><i style="background:#5ac864"></i>High</div>
+        <div><i style="background:#a0ff8c"></i>Peak</div>`;
       return div;
     };
     legend.addTo(map);

--- a/src/flask_app/templates/dashboards/_time_content.html
+++ b/src/flask_app/templates/dashboards/_time_content.html
@@ -1,78 +1,135 @@
 {# Partial: temporal dashboard content. Used by dashboards/time.html and the merged dashboards page. #}
 
 <style>
-  .chart-container {
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
+  .temporal-wrap {
+    max-width: 850px;
+    margin: 0 auto;
+    padding-top: 1.5rem;
   }
-  .chart-container h3 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    color: var(--text);
-  }
-  .chart-container canvas { width: 100% !important; height: 280px !important; }
   .controls {
     display: flex;
     align-items: center;
     gap: 1rem;
+    margin-bottom: 2rem;
+    font-family: 'Courier New', monospace;
+    font-weight: 700;
+  }
+  .controls label {
+    color: #5a9b6e;
+    font-size: 0.85rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+  .controls select {
+    background: rgba(20, 30, 40, 0.92);
+    color: #e6edf3;
+    border: 1px solid rgba(90, 155, 110, 0.3);
+    border-radius: 4px;
+    padding: 0.45rem 0.9rem;
+    font-family: 'Courier New', monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    min-width: 220px;
+    cursor: pointer;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .controls select:focus,
+  .controls select:hover {
+    outline: none;
+    border-color: #5a9b6e;
+    box-shadow: 0 0 8px rgba(90, 155, 110, 0.3);
+  }
+  .loading {
+    color: #8b949e;
+    font-size: 0.75rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-left: 0.5rem;
+  }
+
+  .chart-container {
+    background: rgba(20, 30, 40, 0.45);
+    border: 1px solid rgba(90, 155, 110, 0.2);
+    border-radius: 4px;
+    padding: 1.5rem 1.75rem;
     margin-bottom: 1.5rem;
   }
-  .controls label { color: var(--text-muted); font-size: 0.9rem; }
-  .controls select {
-    background: var(--bg-card);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 0.4rem 0.8rem;
-    font-family: 'DM Sans', sans-serif;
-    font-size: 0.9rem;
-    min-width: 220px;
+  .chart-container h3 {
+    font-family: 'Courier New', monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: #5a9b6e;
+    margin-bottom: 1rem;
   }
-  .controls select:focus { outline: none; border-color: var(--accent); }
-  .loading { color: var(--text-muted); font-size: 0.85rem; margin-left: 0.5rem; }
+  .chart-container h3::before {
+    content: '// ';
+    color: rgba(90, 155, 110, 0.6);
+  }
+  .chart-container canvas { width: 100% !important; height: 280px !important; }
+
   .heatmap-wrapper { overflow-x: auto; }
-  .heatmap-table { border-collapse: collapse; width: 100%; font-size: 0.8rem; }
+  .heatmap-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-family: 'Courier New', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+  }
   .heatmap-table th {
     padding: 6px 8px;
-    color: var(--text-muted);
-    font-weight: 500;
+    color: #5a9b6e;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
     text-align: center;
+    font-size: 0.65rem;
   }
   .heatmap-table td {
-    padding: 6px 8px;
+    padding: 5px 8px;
     text-align: center;
-    color: #111;
-    font-weight: 500;
-    font-size: 0.75rem;
-    border-radius: 2px;
+    color: #e6edf3;
+    font-weight: 700;
+    font-size: 0.7rem;
+    letter-spacing: 0.02em;
+    border: 1px solid rgba(20, 30, 40, 0.5);
   }
-  .heatmap-table .hour-label { color: var(--text-muted); text-align: right; font-weight: 500; }
+  .heatmap-table .hour-label {
+    color: #8b949e;
+    text-align: right;
+    font-weight: 700;
+    background: transparent !important;
+    border: none;
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+  }
 </style>
 
-<div class="controls">
-  <label for="crimeType">Crime Type:</label>
-  <select id="crimeType"><option value="ALL">All Types</option></select>
-  <span class="loading" id="loadingMsg" style="display:none">Loading...</span>
-</div>
+<div class="temporal-wrap">
+  <div class="controls">
+    <label for="crimeType">Crime Type &gt;</label>
+    <select id="crimeType"><option value="ALL">All Types</option></select>
+    <span class="loading" id="loadingMsg" style="display:none">// loading...</span>
+  </div>
 
-<div class="chart-container">
-  <h3>Total Crime Incidents by Year (2002–2025)</h3>
-  <canvas id="yearChart"></canvas>
-</div>
+  <div class="chart-container">
+    <h3>Total Crime Incidents by Year (2002–2025)</h3>
+    <canvas id="yearChart"></canvas>
+  </div>
 
-<div class="chart-container">
-  <h3>Average Crime Count by Month (Seasonality)</h3>
-  <canvas id="monthChart"></canvas>
-</div>
+  <div class="chart-container">
+    <h3>Average Crime Count by Month (Seasonality)</h3>
+    <canvas id="monthChart"></canvas>
+  </div>
 
-<div class="chart-container">
-  <h3>Crime Incidents by Hour and Day of Week</h3>
-  <div class="heatmap-wrapper">
-    <table class="heatmap-table" id="heatmapTable"></table>
+  <div class="chart-container">
+    <h3>Crime Incidents by Hour and Day of Week</h3>
+    <div class="heatmap-wrapper">
+      <table class="heatmap-table" id="heatmapTable"></table>
+    </div>
   </div>
 </div>
 
@@ -81,8 +138,20 @@
   let yearChart, monthChart;
   const monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 
-  function initChart(id, type, labels, data, label, color) {
+  // Color tokens
+  const COLOR_LINE = '#a0ff8c';
+  const COLOR_BAR = '#3b6f4a';
+  const COLOR_GRID = 'rgba(90, 155, 110, 0.08)';
+  const COLOR_TICK = '#8b949e';
+  const COLOR_TOOLTIP_BG = 'rgba(20, 30, 40, 0.95)';
+  const COLOR_TOOLTIP_BORDER = '#5a9b6e';
+  const COLOR_TOOLTIP_TEXT = '#e6edf3';
+
+  function initChart(id, type, labels, data, label) {
     const ctx = document.getElementById(id).getContext('2d');
+    const isLine = type === 'line';
+    const color = isLine ? COLOR_LINE : COLOR_BAR;
+
     return new Chart(ctx, {
       type: type,
       data: {
@@ -91,11 +160,14 @@
           label: label,
           data: data,
           borderColor: color,
-          backgroundColor: type === 'bar' ? color + 'CC' : color + '33',
-          borderWidth: 2,
-          pointRadius: type === 'line' ? 3 : 0,
+          backgroundColor: isLine ? 'rgba(160, 255, 140, 0.08)' : 'rgba(59, 111, 74, 0.85)',
+          borderWidth: isLine ? 2 : 1,
+          pointRadius: isLine ? 3 : 0,
+          pointBackgroundColor: color,
+          pointBorderColor: '#1a2a3a',
+          pointBorderWidth: 1.5,
           tension: 0.3,
-          fill: type === 'line'
+          fill: isLine
         }]
       },
       options: {
@@ -104,16 +176,36 @@
         plugins: {
           legend: { display: false },
           tooltip: {
+            backgroundColor: COLOR_TOOLTIP_BG,
+            borderColor: COLOR_TOOLTIP_BORDER,
+            borderWidth: 1,
+            titleColor: COLOR_TOOLTIP_BORDER,
+            bodyColor: COLOR_TOOLTIP_TEXT,
+            titleFont: { family: 'Courier New', weight: 'bold', size: 11 },
+            bodyFont: { family: 'Courier New', weight: 'bold', size: 12 },
+            padding: 10,
+            cornerRadius: 2,
+            displayColors: false,
             callbacks: {
               label: (ctx) => ctx.parsed.y.toLocaleString()
             }
           }
         },
         scales: {
-          x: { ticks: { color: '#94a3b8' }, grid: { color: '#1e293b' } },
+          x: {
+            ticks: {
+              color: COLOR_TICK,
+              font: { family: 'Courier New', size: 10 }
+            },
+            grid: { color: COLOR_GRID }
+          },
           y: {
-            ticks: { color: '#94a3b8', callback: v => v.toLocaleString() },
-            grid: { color: '#1e293b' },
+            ticks: {
+              color: COLOR_TICK,
+              font: { family: 'Courier New', size: 10 },
+              callback: v => v.toLocaleString()
+            },
+            grid: { color: COLOR_GRID },
             beginAtZero: true
           }
         }
@@ -127,19 +219,38 @@
     const maxVal = Math.max(...allVals);
     const minVal = Math.min(...allVals);
 
+    // Map normalized value → color along map's gradient (slate → green)
     function heatColor(val) {
       const t = maxVal === minVal ? 0 : (val - minVal) / (maxVal - minVal);
-      const r = Math.round(255);
-      const g = Math.round(255 - t * 200);
-      const b = Math.round(50 + (1 - t) * 150);
-      return `rgb(${r},${g},${b})`;
+
+      // Stops mirroring map gradient
+      const stops = [
+        { p: 0.0,  c: [40, 60, 80] },
+        { p: 0.15, c: [50, 75, 95] },
+        { p: 0.35, c: [60, 110, 105] },
+        { p: 0.55, c: [75, 155, 110] },
+        { p: 0.75, c: [110, 200, 120] },
+        { p: 1.0,  c: [160, 255, 140] }
+      ];
+
+      for (let i = 0; i < stops.length - 1; i++) {
+        const a = stops[i], b = stops[i + 1];
+        if (t >= a.p && t <= b.p) {
+          const local = (t - a.p) / (b.p - a.p);
+          const r = Math.round(a.c[0] + (b.c[0] - a.c[0]) * local);
+          const g = Math.round(a.c[1] + (b.c[1] - a.c[1]) * local);
+          const bl = Math.round(a.c[2] + (b.c[2] - a.c[2]) * local);
+          return `rgb(${r},${g},${bl})`;
+        }
+      }
+      return 'rgb(40,60,80)';
     }
 
     let html = '<thead><tr><th></th>';
     days.forEach(d => { html += `<th>${d.slice(0,3)}</th>`; });
     html += '</tr></thead><tbody>';
     hours.forEach((h, i) => {
-      html += `<tr><td class="hour-label">${h}:00</td>`;
+      html += `<tr><td class="hour-label">${String(h).padStart(2,'0')}:00</td>`;
       days.forEach((_, j) => {
         const v = matrix[i][j];
         html += `<td style="background:${heatColor(v)}">${v.toLocaleString()}</td>`;
@@ -160,10 +271,10 @@
         msg.style.display = 'none';
 
         if (yearChart) yearChart.destroy();
-        yearChart = initChart('yearChart', 'line', data.by_year.years, data.by_year.counts, 'Incidents', '#3b82f6');
+        yearChart = initChart('yearChart', 'line', data.by_year.years, data.by_year.counts, 'Incidents');
 
         if (monthChart) monthChart.destroy();
-        monthChart = initChart('monthChart', 'bar', monthNames, data.by_month.counts, 'Avg Incidents', '#3b82f6');
+        monthChart = initChart('monthChart', 'bar', monthNames, data.by_month.counts, 'Avg Incidents');
 
         renderHeatmap(data.heatmap.matrix, data.heatmap.days, data.heatmap.hours);
 
@@ -180,7 +291,7 @@
         }
       })
       .catch(err => {
-        msg.textContent = 'Error loading data';
+        msg.textContent = '// error loading data';
         console.error(err);
       });
   }


### PR DESCRIPTION
## What this PR does

Restyles the spatial and temporal dashboards to match the terminal-forensic design system. Visual tokens only — no structural changes.

**Spatial**
- Heatmap rebuilt as discrete green points (deep forest → luminous pale green); `max` raised so cluster intensity reflects real density
- Cluster markers, year slider, and legend all restyled to match: dark fill, green hairline border, Courier mono text, `//` prefixes

**Temporal**
- Line chart in luminous green, bar chart in deep green
- Heatmap table reuses the spatial gradient (slate → green) for visual continuity
- Chart titles, tooltips, controls all switched to Courier mono with terminal-style prompts
- Charts wrapped in `max-width: 1100px` container so they don't span the full viewport

## How to test

- [x] **`/dashboards#spatial`** — green heatmap, dark cluster markers, green slider, 5-stop legend
- [x] **`/dashboards#temporal`** — green line chart, green bar chart, green heatmap table, mono tooltips, width-constrained
- [x] **Crime type filter** still updates all three temporal charts
- [x] **Year slider** still drives the spatial heatmap
- [x] **`/dashboards/space` and `/dashboards/time`** deep links inherit the same styling

## Next steps

- Algorithm-comparison interface still pending (separate work)